### PR TITLE
added front end kgen.py executable.

### DIFF
--- a/Test/unit_tests/Makefile.kgen
+++ b/Test/unit_tests/Makefile.kgen
@@ -74,7 +74,7 @@ gendata: extract
         fi;
 
 extract: copy
-	@python ${KGEN_ROOT}/kgen.py \
+	@${KGEN_ROOT}/kgen.py \
 	    -D ROW=4,COLUMN=4 \
 	    -I ${TMP_DIR} \
 	    --state-build cmds="cd ${TMP_DIR}; make clean; make build" \

--- a/example/simple-MPI/Makefile
+++ b/example/simple-MPI/Makefile
@@ -9,7 +9,7 @@ FC_FLAGS := -O3
 MPI_INC := /ncar/opt/intel/12.1.0.233/impi/4.0.3.008/intel64/include
 
 test:
-	python ${KGEN} \
+	${KGEN} \
 		-D ROW=4,COL=4 \
 		-I ${SRC_DIR}:${MPI_INC} \
 		-e exclude.ini \

--- a/example/simple/Makefile
+++ b/example/simple/Makefile
@@ -8,7 +8,7 @@ FC := ifort
 FC_FLAGS := -O3
 
 test:
-	python ${KGEN} \
+	${KGEN} \
 		-D ROW=4,COLUMN=4 \
 		-I ${SRC_DIR} \
 		--timing repeat=1000 \

--- a/kgen/kgen.py
+++ b/kgen/kgen.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 This is the main KGEN script.
 ________________________


### PR DESCRIPTION
Now kgen can be executed by simply typing <path_to_kgen>/kgen.py. Changed example and test scripts to reflect the same.